### PR TITLE
Fix retrieval of fixed parameters

### DIFF
--- a/xtion-control.c
+++ b/xtion-control.c
@@ -125,7 +125,7 @@ int xtion_read_fixed_params(struct xtion* xtion)
 	u8 *dest = (u8*)&xtion->fixed;
 
 	request.header.magic = XTION_MAGIC_HOST;
-	request.header.size = 0;
+	request.header.size = 1;
 	request.header.opcode = XTION_OPCODE_GET_FIXED_PARAMS;
 	request.header.id = 0;
 


### PR DESCRIPTION
The size of all control requests is the (sizeof(request) - sizeof(header)) / sizeof(u16). In fact most of the protocol treats offsets/sizes as 2-byte words, except for the offset in the get fixed params request.

I know you're not using the fixed params currently, but there is some useful information in there (such as the coefficients used to build the LUT table), which can vary from device to device.
