### PR TITLE
'install' and 'clean' target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,18 @@ else
 
 KDIR ?= /lib/modules/`uname -r`/build
 
-default:
+default: modules
+
+modules: 
 	$(MAKE) -C $(KDIR) M=$$PWD
+
+install: modules_install
+
+modules_install:
+	make -C $(KDIR) M=$$PWD modules_install
+
+clean:
+	make -C $(KDIR) M=$$PWD clean
 
 test:
 	gcc $(CFLAGS) xtion-math-emu-tests.c -o xtion-math-emu-tests


### PR DESCRIPTION
added some targets to the Makefile in order to allow classc module make target: clean, modules, modules_install ...