### PR TITLE
fixed compilation issues for x86_64 and armv7a (raspberry pi 2)

### DIFF
--- a/xtion-depth.h
+++ b/xtion-depth.h
@@ -6,7 +6,6 @@
 #define XTION_DEPTH_H
 
 #include "xtion.h"
-#include <asm/i387.h>
 
 // Defines from OpenNI2
 #define MAX_SHIFT_VALUE       2047

--- a/xtion-math-emu.h
+++ b/xtion-math-emu.h
@@ -2,7 +2,6 @@
 #define XTION_MATH_EMU_H
 
 #include <linux/types.h>
-
 #define xtion_max(a, b) (a > b ? a: b)
 #define xtion_min(a, b) (a < b ? a: b)
 
@@ -78,8 +77,14 @@ int div_f32(float32* a, float32* b)
 	bb = (b->mantisa | 0x800000);
 	bb = bb << (shift - a->exp);
 
+#if defined(__arm__)
+	// ARM kernel modules do not support 64-bit by 64-bit divison without using emulation
+	// 32-bit seems to suffice (for most cases)
+	mantisa = (u32)aa / (u32)bb;
+#else
 	mantisa = aa / bb;
-	
+#endif
+
 	// rounding
 	//if (aa % bb > bb / 2)
 	//	mantisa += 1;


### PR DESCRIPTION
### xtion-depth.c

  added missing include to < linux/slab.h > for kzalloc and kfree
  removed unused variable
  removed unnecessary floating-point operations by casting to int
  fixed remaining hardware float-op by using the mul_f32 emulation
### xtion-depth.h

  removed unnecessary? include to < asm/i387.h >
    failed to build on arm devices
### xtion-math-emu.h

  arm will use 32-bit by 32-bit diff for div_f32
    64-bit by 64-bit is not supported in kernel-space without emulation:
      "__aeabi_uldivmod" undefined
      and 32-bit by 32-bit seems to suffice
